### PR TITLE
Working QT window

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,12 +32,14 @@
           # Overrides for PySide6
           # https://github.com/nix-community/poetry2nix/issues/1191#issuecomment-1707590287
           pyside6 = final.pkgs.python312.pkgs.pyside6;
-          #shiboken6 = final.pkgs.python3.pkgs.shiboken6;
+          #shiboken6 = final.pkgs.python312.pkgs.shiboken6;
         });
 
         pythonRelaxDeps = [ ];
 
         dependencies = (with pkgs; [
+          pkgs.python312.pkgs.distutils
+
           zlib
           dbus
           fontconfig

--- a/poetry.lock
+++ b/poetry.lock
@@ -727,4 +727,4 @@ zarr = ["fsspec", "zarr"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.*"
-content-hash = "3fb440d2500750c36dbf9bead05dbe084d8e341deadf9172c356a1b86246ae4e"
+content-hash = "41c3ff5a35d843b256f408580ffe70c846987c09b4278da739c59eacaafa8e09"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ cython = "*"
 psutil = "*"
 psd-tools = "*"
 opencv-python = "*"
-numpy = "*"
+#numpy = "*"
 pyrsistent = "*"
 PySide6 = "*"
 


### PR DESCRIPTION
Add _distutils_ dependency to get a working QT window.

Use `distutils` from _nixpkgs_ as a workaround to successfully create a derivation.

In the long run, `python312.pkgs.pyside6` (and probably also `python312.pkgs.distutils`) should be replaced by appropriate overrides for _poetry2nix_. Until then, the same _nixpkgs_ must provide both, the Python version for the application and the PySide6 package. A _nixpkgs_ and Python version independent of PySide6 can only be achieved with corrected overrides.


```SH
$> nix develop .

$> poetry install

$> poetry run crowpainter
# or …
$> nix run
```

![Screenshot_20240908_223919](https://github.com/user-attachments/assets/16d87a64-95a5-4021-8ad3-b54f7d293bc2)
